### PR TITLE
Add Django feature parity items for migration from static site

### DIFF
--- a/src/blog/templates/blog/blog_page.html
+++ b/src/blog/templates/blog/blog_page.html
@@ -1,5 +1,36 @@
 {% extends "core/base.html" %}
 {% load wagtailcore_tags wagtailimages_tags %}
+
+{% block title %}{{ page.title }} | Wiwa{% endblock title %}
+
+{% block meta_description %}
+    {% if page.description %}
+        <meta name="description" content="{{ page.description }}" />
+    {% else %}
+        <meta name="description" content="{{ page.title }}" />
+    {% endif %}
+{% endblock meta_description %}
+
+{% block og_type %}article{% endblock og_type %}
+{% block og_title %}{{ page.title }}{% endblock og_title %}
+{% block og_description %}
+    {% if page.description %}
+        <meta property="og:description" content="{{ page.description }}" />
+    {% else %}
+        <meta property="og:description" content="{{ page.title }}" />
+    {% endif %}
+{% endblock og_description %}
+{% block og_url %}<meta property="og:url" content="{{ page.full_url }}" />{% endblock og_url %}
+
+{% block twitter_title %}{{ page.title }}{% endblock twitter_title %}
+{% block twitter_description %}
+    {% if page.description %}
+        <meta name="twitter:description" content="{{ page.description }}" />
+    {% else %}
+        <meta name="twitter:description" content="{{ page.title }}" />
+    {% endif %}
+{% endblock twitter_description %}
+
 {% block main %}
     <article class="pb-4 blog-page">
         <h1 class="font-medium text-4xl mb-2">{{ page.title }}</h1>

--- a/src/blog/views.py
+++ b/src/blog/views.py
@@ -3,6 +3,7 @@ from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Atom1Feed
 from django.views.generic import TemplateView
 from jsonfeed import JSONFeed
+from wagtail.rich_text import RichText
 
 from blog.models import BlogPage
 
@@ -14,13 +15,40 @@ class IndexView(TemplateView):
 class RssFeed(Feed):
     title = "Wiwa"
     description = "The Ramblings of Wiwa"
-    link = "/blog/feed/"
+    link = "/blog/"
 
     def items(self):
-        return BlogPage.objects.all()
+        return BlogPage.objects.live().order_by("-date")
+
+    def item_title(self, item: BlogPage) -> str:
+        return item.title
 
     def item_link(self, item: BlogPage) -> str:
         return item.url
+
+    def item_pubdate(self, item: BlogPage):
+        return item.first_published_at
+
+    def item_updateddate(self, item: BlogPage):
+        return item.latest_revision_created_at
+
+    def item_description(self, item: BlogPage) -> str:
+        """Return the content before the fold, or description if set."""
+        if item.description:
+            return item.description
+
+        # Render content before the fold
+        content_parts = []
+        for block in item.before_the_fold():
+            if isinstance(block, str):
+                content_parts.append(block)
+            elif hasattr(block, "render"):
+                content_parts.append(str(block.render()))
+            elif isinstance(block.value, RichText):
+                content_parts.append(str(block.value))
+            else:
+                content_parts.append(str(block.value))
+        return "".join(content_parts)
 
 
 class AtomFeed(RssFeed):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -89,6 +89,7 @@ INSTALLED_APPS = [
     "blog.apps.BlogConfig",
     "admin_core.apps.AdminCoreConfig",
     "admin_utils.apps.AdminUtilsConfig",
+    "django.contrib.sitemaps",
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",
     "wagtail.embeds",

--- a/src/config/urls/prod.py
+++ b/src/config/urls/prod.py
@@ -16,8 +16,17 @@ Including another URLconf
 """
 
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
 from django.views.generic.base import RedirectView
+
+from core.sitemaps import BlogIndexSitemap, BlogSitemap, StaticViewSitemap
+
+sitemaps = {
+    "static": StaticViewSitemap,
+    "blog": BlogSitemap,
+    "blog_index": BlogIndexSitemap,
+}
 
 urlpatterns = [
     path("", include("core.urls.prod")),
@@ -25,6 +34,12 @@ urlpatterns = [
     path("blog/", include("blog.urls")),
     # path("accounts/", include("django.contrib.auth.urls")),
     path("admin/", admin.site.urls),
+    path(
+        "sitemap.xml",
+        sitemap,
+        {"sitemaps": sitemaps},
+        name="django.contrib.sitemaps.views.sitemap",
+    ),
     path(
         "feed/blog/",
         include(

--- a/src/core/sitemaps.py
+++ b/src/core/sitemaps.py
@@ -1,0 +1,42 @@
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+from wagtail.models import Page
+
+from blog.models import BlogPage
+
+
+class StaticViewSitemap(Sitemap):
+    priority = 0.5
+    changefreq = "monthly"
+
+    def items(self):
+        return ["core:index", "core:projects", "core:code-of-points"]
+
+    def location(self, item):
+        return reverse(item)
+
+
+class BlogSitemap(Sitemap):
+    priority = 0.6
+    changefreq = "weekly"
+
+    def items(self):
+        return BlogPage.objects.live().order_by("-date")
+
+    def lastmod(self, obj):
+        return obj.latest_revision_created_at
+
+    def location(self, obj):
+        return obj.url
+
+
+class BlogIndexSitemap(Sitemap):
+    priority = 0.8
+    changefreq = "daily"
+
+    def items(self):
+        return ["blog_index"]
+
+    def location(self, item):
+        # Blog index is at /blog/
+        return "/blog/"

--- a/src/core/templates/404.html
+++ b/src/core/templates/404.html
@@ -1,0 +1,14 @@
+{% extends "core/base.html" %}
+{% block title %}Page Not Found{% endblock title %}
+{% block main %}
+    <div class="text-center py-20">
+        <h1 class="text-6xl font-bold text-gray-300 mb-4">404</h1>
+        <h2 class="text-2xl font-medium mb-4">Page Not Found</h2>
+        <p class="text-gray-600 mb-8">
+            The page you're looking for doesn't exist or has been moved.
+        </p>
+        <a href="/" class="inline-block px-6 py-3 bg-blue-600 text-white no-underline rounded hover:bg-blue-700">
+            Go Home
+        </a>
+    </div>
+{% endblock main %}

--- a/src/core/templates/500.html
+++ b/src/core/templates/500.html
@@ -1,0 +1,14 @@
+{% extends "core/base.html" %}
+{% block title %}Server Error{% endblock title %}
+{% block main %}
+    <div class="text-center py-20">
+        <h1 class="text-6xl font-bold text-gray-300 mb-4">500</h1>
+        <h2 class="text-2xl font-medium mb-4">Server Error</h2>
+        <p class="text-gray-600 mb-8">
+            Something went wrong on our end. Please try again later.
+        </p>
+        <a href="/" class="inline-block px-6 py-3 bg-blue-600 text-white no-underline rounded hover:bg-blue-700">
+            Go Home
+        </a>
+    </div>
+{% endblock main %}

--- a/src/core/templates/core/base.html
+++ b/src/core/templates/core/base.html
@@ -2,13 +2,38 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charSet="UTF-8" />
+        <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>
             {% block title %}
                 Wiwa
             {% endblock title %}
         </title>
+        {% block meta_description %}
+            <meta name="description" content="Luke Wiwatowski - Gymnastics, Engineering, Miscellaneous" />
+        {% endblock meta_description %}
+
+        <!-- Open Graph / Facebook -->
+        <meta property="og:type" content="{% block og_type %}website{% endblock og_type %}" />
+        <meta property="og:title" content="{% block og_title %}Wiwa{% endblock og_title %}" />
+        {% block og_description %}
+            <meta property="og:description" content="Luke Wiwatowski - Gymnastics, Engineering, Miscellaneous" />
+        {% endblock og_description %}
+        <meta property="og:site_name" content="Wiwa" />
+        {% block og_url %}{% endblock og_url %}
+
+        <!-- Twitter -->
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="{% block twitter_title %}Wiwa{% endblock twitter_title %}" />
+        {% block twitter_description %}
+            <meta name="twitter:description" content="Luke Wiwatowski - Gymnastics, Engineering, Miscellaneous" />
+        {% endblock twitter_description %}
+
+        <!-- Feeds -->
+        <link rel="alternate" type="application/rss+xml" title="Wiwa RSS Feed" href="/blog/feed/rss.xml" />
+        <link rel="alternate" type="application/atom+xml" title="Wiwa Atom Feed" href="/blog/feed/atom.xml" />
+        <link rel="alternate" type="application/json" title="Wiwa JSON Feed" href="/blog/feed/feed.json" />
+
         <link rel="stylesheet" href="{% static "frontend/index.css" %}">
         {% include "wagtail_highlight/includes/highlight_script.html" %}
     </head>

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://lukewiwa.com/sitemap.xml

--- a/src/wagtail_highlight/frontend/highlight-themes.css
+++ b/src/wagtail_highlight/frontend/highlight-themes.css
@@ -1,0 +1,97 @@
+/* Light theme (default) */
+@import "highlight.js/styles/github.css";
+
+/* Dark theme override */
+@media (prefers-color-scheme: dark) {
+  .hljs {
+    color: #c9d1d9;
+    background: #0d1117;
+  }
+
+  .hljs-doctag,
+  .hljs-keyword,
+  .hljs-meta .hljs-keyword,
+  .hljs-template-tag,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable.language_ {
+    color: #ff7b72;
+  }
+
+  .hljs-title,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-title.function_ {
+    color: #d2a8ff;
+  }
+
+  .hljs-attr,
+  .hljs-attribute,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-operator,
+  .hljs-variable,
+  .hljs-selector-attr,
+  .hljs-selector-class,
+  .hljs-selector-id {
+    color: #79c0ff;
+  }
+
+  .hljs-regexp,
+  .hljs-string,
+  .hljs-meta .hljs-string {
+    color: #a5d6ff;
+  }
+
+  .hljs-built_in,
+  .hljs-symbol {
+    color: #ffa657;
+  }
+
+  .hljs-comment,
+  .hljs-code,
+  .hljs-formula {
+    color: #8b949e;
+  }
+
+  .hljs-name,
+  .hljs-quote,
+  .hljs-selector-tag,
+  .hljs-selector-pseudo {
+    color: #7ee787;
+  }
+
+  .hljs-subst {
+    color: #c9d1d9;
+  }
+
+  .hljs-section {
+    color: #1f6feb;
+    font-weight: bold;
+  }
+
+  .hljs-bullet {
+    color: #f2cc60;
+  }
+
+  .hljs-emphasis {
+    color: #c9d1d9;
+    font-style: italic;
+  }
+
+  .hljs-strong {
+    color: #c9d1d9;
+    font-weight: bold;
+  }
+
+  .hljs-addition {
+    color: #aff5b4;
+    background-color: #033a16;
+  }
+
+  .hljs-deletion {
+    color: #ffdcd7;
+    background-color: #67060c;
+  }
+}

--- a/src/wagtail_highlight/frontend/highlight.tsx
+++ b/src/wagtail_highlight/frontend/highlight.tsx
@@ -1,5 +1,5 @@
 import hljs from "highlight.js";
-// Styles are loaded via CDN in the template for dark mode support
+import "./highlight-themes.css";
 
 const highlightContainers = document.querySelectorAll(
   `code[data-wagtail-highlight="container"]`

--- a/src/wagtail_highlight/frontend/highlight.tsx
+++ b/src/wagtail_highlight/frontend/highlight.tsx
@@ -1,5 +1,5 @@
 import hljs from "highlight.js";
-import "highlight.js/styles/default.css";
+// Styles are loaded via CDN in the template for dark mode support
 
 const highlightContainers = document.querySelectorAll(
   `code[data-wagtail-highlight="container"]`

--- a/src/wagtail_highlight/templates/wagtail_highlight/includes/highlight_script.html
+++ b/src/wagtail_highlight/templates/wagtail_highlight/includes/highlight_script.html
@@ -1,5 +1,3 @@
 {% load static %}
-<!-- Highlight.js themes with dark mode support -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="screen and (prefers-color-scheme: dark)" />
+<link rel="stylesheet" href="{% static "wagtail_highlight/highlight.css" %}">
 <script async src="{% static "wagtail_highlight/highlight.js" %}"></script>

--- a/src/wagtail_highlight/templates/wagtail_highlight/includes/highlight_script.html
+++ b/src/wagtail_highlight/templates/wagtail_highlight/includes/highlight_script.html
@@ -1,3 +1,5 @@
 {% load static %}
-<link rel="stylesheet" href="{% static "wagtail_highlight/highlight.css" %}">
+<!-- Highlight.js themes with dark mode support -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="screen and (prefers-color-scheme: dark)" />
 <script async src="{% static "wagtail_highlight/highlight.js" %}"></script>


### PR DESCRIPTION
- Add sitemap.xml with Django sitemaps for static pages and blog posts
- Add robots.txt with sitemap reference
- Enhance RSS/Atom/JSON feed views with item descriptions, dates, and content
- Add custom 404 and 500 error pages
- Add SEO meta tags (Open Graph, Twitter cards) to base template
- Add blog-specific meta tags to blog post template
- Add dark mode support for code highlighting via CDN stylesheets
- Add feed autodiscovery links to base template