### PR TITLE
Migrate Makefile to justfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -81,6 +81,7 @@
 		"ghcr.io/dhoeric/features/hadolint:1": {},
 		"ghcr.io/devcontainers-community/features/deno": {
 			"version": "1.46.3"
-		}
+		},
+		"ghcr.io/devcontainers-contrib/features/just:1": {}
 	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR ${FUNCTION_DIR}
 
 FROM base AS builder
 
-RUN apt update && apt install curl make --yes
+RUN apt update && apt install curl --yes
 
 # Install node https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
 ARG NODE_VERSION

--- a/justfile
+++ b/justfile
@@ -15,11 +15,8 @@ static-watch:
 	npm --prefix=src run dev
 
 # Start both python server and static watch in parallel
-start:
-	#!/usr/bin/env bash
-	set -euo pipefail
-	trap 'kill 0' SIGINT SIGTERM
-	just python-server & just static-watch & wait
+[parallel]
+start: python-server static-watch
 
 # Deploy infrastructure using CDK
 deploy:

--- a/justfile
+++ b/justfile
@@ -16,7 +16,10 @@ static-watch:
 
 # Start both python server and static watch in parallel
 start:
-	just python-server & just static-watch
+	#!/usr/bin/env bash
+	set -euo pipefail
+	trap 'kill 0' SIGINT SIGTERM
+	just python-server & just static-watch & wait
 
 # Deploy infrastructure using CDK
 deploy:

--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
+# Default recipe - show available commands
+default:
+	@just --list
+
 # Run Django development server
 python-server:
 	cd src && uv run ./manage.py runserver 0.0.0.0:8000
@@ -17,3 +21,101 @@ start:
 # Deploy infrastructure using CDK
 deploy:
 	cd infra && npm run cdk -- deploy --all --require-approval never
+
+# Django commands
+
+# Run Django migrations
+migrate:
+	cd src && uv run ./manage.py migrate
+
+# Create Django migrations
+makemigrations:
+	cd src && uv run ./manage.py makemigrations
+
+# Open Django shell
+shell:
+	cd src && uv run ./manage.py shell
+
+# Create Django superuser
+createsuperuser:
+	cd src && uv run ./manage.py createsuperuser
+
+# Linting and formatting
+
+# Run ruff linter on Python code
+lint-python:
+	cd src && uv run ruff check .
+
+# Format Python code with ruff
+format-python:
+	cd src && uv run ruff format .
+
+# Fix Python linting issues automatically
+fix-python:
+	cd src && uv run ruff check --fix .
+
+# Run eslint on JavaScript/TypeScript code
+lint-js:
+	npm --prefix=src run lint
+
+# Lint Django templates with djlint
+lint-templates:
+	cd src && uv run djlint --check .
+
+# Format Django templates with djlint
+format-templates:
+	cd src && uv run djlint --reformat .
+
+# Run all linters
+lint: lint-python lint-js lint-templates
+
+# Format all code
+format: format-python format-templates
+
+# Deno static site commands
+
+# Build static site with Lume
+lume-build:
+	deno task build
+
+# Serve static site with Lume
+lume-serve:
+	deno task serve
+
+# Infrastructure commands
+
+# Build infrastructure TypeScript
+infra-build:
+	cd infra && npm run build
+
+# Run infrastructure tests
+infra-test:
+	cd infra && npm test
+
+# Watch infrastructure TypeScript changes
+infra-watch:
+	cd infra && npm run watch
+
+# Build frontend TypeScript
+frontend-build:
+	npm --prefix=src run build
+
+# Type check frontend
+frontend-typecheck:
+	npm --prefix=src run build
+
+# Development helpers
+
+# Install all dependencies
+install:
+	cd src && uv sync
+	npm --prefix=src install
+	cd infra && npm install
+
+# Clean build artifacts
+clean:
+	rm -rf src/staticfiles
+	rm -rf src/frontend/dist
+	rm -rf infra/cdk.out
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete

--- a/justfile
+++ b/justfile
@@ -1,21 +1,19 @@
-MAKEFLAGS += --jobs
-
-.PHONY: python-server
+# Run Django development server
 python-server:
 	cd src && uv run ./manage.py runserver 0.0.0.0:8000
 
-.PHONY: static-build
+# Collect static files
 static-build:
 	cd src && uv run ./manage.py collectstatic --noinput --clear
 
-.PHONY: static-watch
+# Watch and build static assets
 static-watch:
 	npm --prefix=src run dev
 
+# Start both python server and static watch in parallel
+start:
+	just python-server & just static-watch
 
-.PHONY: start
-start: python-server static-watch
-
-.PHONY: deploy
+# Deploy infrastructure using CDK
 deploy:
 	cd infra && npm run cdk -- deploy --all --require-approval never


### PR DESCRIPTION
Replace Make with Just for task automation. The justfile provides equivalent functionality with cleaner syntax:
- python-server: Run Django development server
- static-build: Collect static files
- static-watch: Watch and build static assets
- start: Run both python-server and static-watch in parallel
- deploy: Deploy infrastructure using CDK